### PR TITLE
Fix sample reading to limit bytes and report snippet

### DIFF
--- a/mcp/filetag-server.mjs
+++ b/mcp/filetag-server.mjs
@@ -806,7 +806,11 @@ server.registerTool(
       if (shouldRead(f) && samples.length < 12) {
         try {
           const buf = await fs.readFile(f, "utf8");
-          samples.push({ file: path.relative(base, f), first200: buf.slice(0, maxBytes, 200) });
+          // keep up to `maxBytes`, but for reporting keep a short snippet (first 200 chars)
+          samples.push({
+            file: path.relative(base, f),
+            first200: buf.slice(0, Math.min(maxBytes, 200)),
+          });
         } catch {
           samples.push({ file: path.relative(base, f) });
         }


### PR DESCRIPTION
### **User description**
Updated sample file reading to correctly limit bytes and provide a snippet.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed `buf.slice()` call to correctly limit bytes using `Math.min()`

- Ensures sample snippets respect both `maxBytes` limit and 200 char display cap

- Added clarifying comment explaining snippet reporting behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buf.slice with incorrect args"] -- "Fix: use Math.min(maxBytes, 200)" --> B["Correct byte limiting"]
  B --> C["Proper snippet reporting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filetag-server.mjs</strong><dd><code>Fix buffer slicing byte limit calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp/filetag-server.mjs

<ul><li>Fixed <code>buf.slice()</code> invocation to use <code>Math.min(maxBytes, 200)</code> instead of <br>incorrect argument order<br> <li> Added explanatory comment clarifying that snippets are limited to <br><code>maxBytes</code> but reported as first 200 chars<br> <li> Improved code formatting with multi-line object structure for better <br>readability</ul>


</details>


  </td>
  <td><a href="https://github.com/peteywee/fresh-root/pull/69/files#diff-cfbc80c589aa9a4c3f20d02b47dea5c41d7e38e52ce666e363f75079928afcee">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

