### PR TITLE
fix: resolve TypeScript errors for Next.js 16 compatibility

### DIFF
--- a/apps/web/app/api/schedules/route.ts
+++ b/apps/web/app/api/schedules/route.ts
@@ -16,7 +16,7 @@ const parsePositiveInt = (value: string | null, fallback: number) => {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 };
 
-const getPagination = (request: NextRequest) => {
+const getPagination = (request: Request) => {
   const { searchParams } = new URL(request.url);
   return {
     limit: parsePositiveInt(searchParams.get("limit"), 20),
@@ -63,7 +63,7 @@ export interface ShiftDoc {
 /**
  * List schedules for an organization with pagination and type safety
  */
-const listSchedules = async (request: NextRequest, context: RequestContext) => {
+const listSchedules = async (request: Request, context: RequestContext) => {
   const pagination = getPagination(request);
   const { db, error } = getAdminDbOrError();
   if (error) {
@@ -96,7 +96,7 @@ const listSchedules = async (request: NextRequest, context: RequestContext) => {
 /**
  * Create a new schedule with full type safety
  */
-const createSchedule = async (request: NextRequest, context: RequestContext) => {
+const createSchedule = async (request: Request, context: RequestContext) => {
   const parsed = await parseJson(request, CreateScheduleSchema);
   if (!parsed.success) {
     return badRequest("Invalid payload", parsed.details);

--- a/apps/web/src/lib/imports/_template.import.ts
+++ b/apps/web/src/lib/imports/_template.import.ts
@@ -1,6 +1,7 @@
 // [P2][APP][CODE]  Template Import
 // Tags: P2, APP, CODE
 import ExcelJS from "exceljs";
+import type { Row, Cell } from "exceljs";
 import { parse } from "papaparse";
 import { z } from "zod";
 
@@ -26,16 +27,16 @@ export async function importFile(file: File): Promise<ImportResult<z.infer<typeo
     const worksheet = workbook.worksheets[0];
     if (worksheet) {
       const headers: string[] = [];
-      worksheet.eachRow((row, rowNumber) => {
+      worksheet.eachRow((row: Row, rowNumber: number) => {
         if (rowNumber === 1) {
           // First row is headers
-          row.eachCell((cell) => {
+          row.eachCell((cell: Cell) => {
             headers.push(String(cell.value ?? ""));
           });
         } else {
           // Data rows
           const rowData: Record<string, unknown> = {};
-          row.eachCell((cell, colNumber) => {
+          row.eachCell((cell: Cell, colNumber: number) => {
             const header = headers[colNumber - 1];
             if (header) {
               rowData[header] = cell.value;

--- a/docs/remember/NEXTJS16_TYPESCRIPT_MIGRATION.md
+++ b/docs/remember/NEXTJS16_TYPESCRIPT_MIGRATION.md
@@ -1,0 +1,142 @@
+# Next.js 16 TypeScript Migration: Route Params Type Changes
+
+## Problem Statement
+
+Upgrading to Next.js 16 introduced breaking TypeScript changes in route handler signatures. The framework changed how dynamic route parameters are provided to route handlers.
+
+## Root Cause
+
+**Next.js 14 vs Next.js 16 incompatibility:**
+
+### Next.js 14 (Old)
+
+Route handlers receive params as a synchronous `Record<string, string>`:
+
+```typescript
+export const GET = (request: NextRequest, context: { params: Record<string, string> }) =>
+  Promise<NextResponse>;
+```
+
+### Next.js 16 (New)
+
+Route handlers receive params as an asynchronous `Promise<Record<string, string>>`:
+
+```typescript
+export const GET = (request: NextRequest, context: { params: Promise<Record<string, string>> }) =>
+  Promise<NextResponse>;
+```
+
+## Failed Attempts
+
+### Attempt 1: Union Type
+
+**Problem:** Used `Record<string, string> | Promise<Record<string, string>>` to be backward compatible.
+
+**Result:** TypeScript constraint errors in `.next/types/validator.ts`:
+
+```
+error TS2344: Type '{ __tag__: "GET"; __param_type__: { params: Record<string, string> | Promise<Record<string, string>>; } | undefined; }'
+does not satisfy the constraint 'ParamCheck<RouteContext>'
+```
+
+**Why it failed:** Next.js's generated type definitions have strict `ParamCheck` constraints that don't accept unions or undefined params. The constraint explicitly expects the exact signature Next.js generates.
+
+### Attempt 2: Optional Context Parameter
+
+**Problem:** Tried `context?: { params: Promise<Record<string, string>> }` with optional chaining.
+
+**Result:** TS2322 type assignability errors. When returning from factory functions, you can't return a function with optional parameters when the type expects required parameters.
+
+**Why it failed:** TypeScript's parameter variance rules: an optional parameter in a return type is not assignable to a required parameter in the expected type.
+
+## Solution That Worked
+
+### 1. **ExcelJS Type Annotations** (`apps/web/src/lib/imports/_template.import.ts`)
+
+Added type imports from ExcelJS and explicit type annotations to callback parameters:
+
+```typescript
+import type { Row, Cell } from "exceljs";
+
+worksheet.eachRow((row: Row, rowNumber: number) => {
+  row.eachCell((cell: Cell, colNumber: number) => {
+    // ...
+  });
+});
+```
+
+**Why it works:** Callbacks need explicit types when TypeScript strict mode is enabled.
+
+### 2. **API Framework Update** (`packages/api-framework/src/index.ts`)
+
+Updated all endpoint factory return type signatures to use `Promise<Record<string, string>>` exclusively:
+
+```typescript
+export function createEndpoint<TInput = unknown, TOutput = unknown>(
+  config: EndpointConfig<TInput, TOutput>,
+): (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+) => Promise<NextResponse> {
+  return async (
+    request: NextRequest,
+    routeContext: { params: Promise<Record<string, string>> },
+  ) => {
+    const params = await routeContext.params;
+    // ... rest of handler
+  };
+}
+```
+
+**Critical insight:** The return type MUST exactly match what `createEndpoint` returns. All wrapper factories (`createRateLimitedEndpoint`, `createPublicEndpoint`, etc.) must have return types that match the base function's signature.
+
+### 3. **Route Handler Updates** (`apps/web/app/api/schedules/route.ts`)
+
+Changed internal function signatures to accept base `Request` type instead of `NextRequest`:
+
+```typescript
+const listSchedules = async (request: Request, context: RequestContext) => {
+  const { searchParams } = new URL(request.url);
+  // ...
+};
+```
+
+**Why it works:** The base `Request` type is compatible with both Next.js 14 and 16 styles when you're not using version-specific properties like `cookies`, `nextUrl`, etc.
+
+## Key Learnings
+
+1. **Next.js 16 is strict about types:** The generated `.next/types/validator.ts` has explicit constraints that don't accept deviations. You can't use unions or optional parameters.
+
+2. **Return types matter:** When factory functions return other functions, the return type must match exactly. There's no flexibility for "close enough" types.
+
+3. **Await params immediately:** In Next.js 16, you must `await` the params Promise in the handler. Don't pass it downstream without awaiting.
+
+4. **Type compatibility hierarchy:**
+   - `Request` < `NextRequest` (Request is broader, safer for compatibility)
+   - `Promise<T>` cannot be used interchangeably with `T | Promise<T>` in function signatures
+   - Optional parameters in return types are not assignable to required parameters
+
+## Testing
+
+All TypeScript checks pass:
+
+```bash
+pnpm typecheck
+# Tasks: 4 successful, 4 total
+# Successfully compiled all packages
+```
+
+## Files Modified
+
+- `apps/web/src/lib/imports/_template.import.ts` - ExcelJS type annotations
+- `apps/web/app/api/schedules/route.ts` - Request type change
+- `packages/api-framework/src/index.ts` - Promise-based params throughout
+
+## Migration Checklist for Similar Issues
+
+- [ ] Check Next.js version in package.json
+- [ ] Review `.next/types/validator.ts` errors for exact constraint requirements
+- [ ] Update api-framework and factory functions together (don't update partially)
+- [ ] Use `Promise<T>` not `T | Promise<T>` in function signatures
+- [ ] Await params in handler, don't pass Promise downstream
+- [ ] Test with `pnpm typecheck` before committing

--- a/packages/api-framework/src/index.ts
+++ b/packages/api-framework/src/index.ts
@@ -332,7 +332,7 @@ async function logAudit(
  */
 export function createEndpoint<TInput = unknown, TOutput = unknown>(
   config: EndpointConfig<TInput, TOutput>,
-): (request: NextRequest, context?: { params: Record<string, string> }) => Promise<NextResponse> {
+): (request: NextRequest, context: { params: Promise<Record<string, string>> }) => Promise<NextResponse> {
   const {
     auth = "required",
     org = "none",
@@ -343,10 +343,10 @@ export function createEndpoint<TInput = unknown, TOutput = unknown>(
     handler,
   } = config;
 
-  return async (request: NextRequest, routeContext?: { params: Record<string, string> }) => {
+  return async (request: NextRequest, routeContext: { params: Promise<Record<string, string>> }) => {
     const requestId = crypto.randomUUID();
     const startTime = Date.now();
-    const params = routeContext?.params || {};
+    const params = await routeContext.params;
 
     // Initialize context
     const context: RequestContext = {
@@ -620,7 +620,7 @@ export function createRateLimitedEndpoint<TOutput = unknown>(
       params: Record<string, string>;
     }) => Promise<NextResponse>;
   },
-): (req: NextRequest, ctx: any) => Promise<NextResponse> {
+): (req: NextRequest, ctx: { params: Promise<Record<string, string>> }) => Promise<NextResponse> {
   return createEndpoint({
     auth: "none",
     org: "none",

--- a/tests/unit/firebaseTypedWrappers.unit.test.ts
+++ b/tests/unit/firebaseTypedWrappers.unit.test.ts
@@ -32,7 +32,7 @@ function makeRef(id: string) {
         store.set(id, { ...(store.get(id) || {}), ...data });
       } else {
         store.set(id, { ...data });
-  } from "../../apps/web/src/lib/firebase/typed-wrappers";
+      }
     },
     async update(data: any) {
       store.set(id, { ...(store.get(id) || {}), ...data });


### PR DESCRIPTION
### **User description**
## Problem
Upgrading to Next.js 16 introduced breaking TypeScript changes in route handler signatures. The framework changed how dynamic route parameters are provided to route handlers, changing from `Record<string, string>` to `Promise<Record<string, string>>`.

## Solution
Updated the api-framework and route handlers to support Next.js 16's Promise-based params while maintaining type safety.

## Changes
- **api-framework**: Updated `createEndpoint` and all factory functions to accept and await Promise-based params
- **Template import**: Added ExcelJS type imports and explicit type annotations for callback parameters
- **Routes**: Updated schedules route to use base `Request` type for internal functions
- **Test fix**: Fixed corrupted test file with duplicate import statement
- **Documentation**: Added detailed migration guide in `docs/remember/NEXTJS16_TYPESCRIPT_MIGRATION.md`

## Testing
All TypeScript checks pass:
```
pnpm typecheck
# Tasks: 4 successful, 4 total
# Successfully compiled all packages
```

## Related Documentation
See `docs/remember/NEXTJS16_TYPESCRIPT_MIGRATION.md` for detailed analysis of the problem, failed attempts, and why this solution works.


___

### **PR Type**
Bug fix


___

### **Description**
- Update api-framework to support Next.js 16 Promise-based route params

- Add explicit type annotations for ExcelJS Row and Cell callbacks

- Change internal route functions to use base Request type

- Fix corrupted test file with duplicate import statement

- Document Next.js 16 TypeScript migration issues and solutions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Next.js 16<br/>Promise-based params"] -->|"Update signature"| B["api-framework<br/>createEndpoint"]
  B -->|"Apply to all<br/>factories"| C["Route handlers<br/>schedules/route.ts"]
  D["ExcelJS callbacks"] -->|"Add type<br/>annotations"| E["_template.import.ts"]
  F["Test file"] -->|"Fix duplicate<br/>import"| G["firebaseTypedWrappers.test.ts"]
  B --> H["Documentation<br/>NEXTJS16_TYPESCRIPT_MIGRATION.md"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update api-framework for Next.js 16 Promise params</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/api-framework/src/index.ts

<ul><li>Updated <code>createEndpoint</code> return type to use <code>Promise<Record<string, </code><br><code>string>></code> for params<br> <li> Changed route context parameter from optional to required with <br>Promise-based params<br> <li> Added <code>await</code> for params Promise in handler implementation<br> <li> Updated <code>createRateLimitedEndpoint</code> return type signature for <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/peteywee/fresh-root/pull/124/files#diff-50a6a97c45a95cad81b593a505949b6554f129aaa0af797ac2a4cdaeeeb96404">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Change route functions to use base Request type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/app/api/schedules/route.ts

<ul><li>Changed <code>getPagination</code> function parameter from <code>NextRequest</code> to <code>Request</code><br> <li> Updated <code>listSchedules</code> function parameter from <code>NextRequest</code> to <code>Request</code><br> <li> Updated <code>createSchedule</code> function parameter from <code>NextRequest</code> to <code>Request</code></ul>


</details>


  </td>
  <td><a href="https://github.com/peteywee/fresh-root/pull/124/files#diff-f9e6d51f7ebc400313cb1fb4ebf56c8a9dfef330b8c2e3457207bb84ed50f125">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_template.import.ts</strong><dd><code>Add ExcelJS type annotations to callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/lib/imports/_template.import.ts

<ul><li>Added type import for <code>Row</code> and <code>Cell</code> from ExcelJS<br> <li> Added explicit type annotation <code>row: Row</code> to worksheet.eachRow callback<br> <li> Added explicit type annotation <code>rowNumber: number</code> to worksheet.eachRow <br>callback<br> <li> Added explicit type annotation <code>cell: Cell</code> to row.eachCell callbacks<br> <li> Added explicit type annotation <code>colNumber: number</code> to row.eachCell <br>callback</ul>


</details>


  </td>
  <td><a href="https://github.com/peteywee/fresh-root/pull/124/files#diff-745670842288ca49c9b0759a038cad7dde69a085a71f10e43936d509e3bd7f96">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firebaseTypedWrappers.unit.test.ts</strong><dd><code>Fix corrupted test file structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/firebaseTypedWrappers.unit.test.ts

<ul><li>Fixed corrupted test file by removing duplicate import statement<br> <li> Restored proper closing brace for <code>set</code> method in mock object</ul>


</details>


  </td>
  <td><a href="https://github.com/peteywee/fresh-root/pull/124/files#diff-a3974b7ee21efa3bd29688ba38a8fe4d0c2b9dba77cc90119da324dab26a1ca4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NEXTJS16_TYPESCRIPT_MIGRATION.md</strong><dd><code>Document Next.js 16 TypeScript migration guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/remember/NEXTJS16_TYPESCRIPT_MIGRATION.md

<ul><li>Added comprehensive migration guide documenting Next.js 14 vs 16 param <br>type changes<br> <li> Documented failed attempts with union types and optional parameters<br> <li> Explained why solution works with Promise-based params and type <br>compatibility<br> <li> Included key learnings about Next.js 16 type strictness and return <br>type requirements<br> <li> Provided migration checklist for similar TypeScript issues</ul>


</details>


  </td>
  <td><a href="https://github.com/peteywee/fresh-root/pull/124/files#diff-0f9fe33ba9671f1ef3ac5c9fdc6abe898e5b8f39fc004ccf1c38f2c0ca304463">+142/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

